### PR TITLE
Fix error when using the -p command-line option

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ const argv = yargs
   .options({
     p: {
       alias: 'path',
-      describe: 'Use JSON Path notation (https://github.com/dchester/jsonpath)'
+      describe: 'Use JSON Path notation (https://github.com/dchester/jsonpath)',
+      type: 'boolean'
     },
     k: {
       alias: 'keys',
@@ -79,7 +80,7 @@ const parse = (stream) => {
       if (argv.keys) {
         log(format(Object.keys(obj)))
       } else if (argv.path) {
-        log(format(jsonpath.query(obj, argv._[0] || argv.path)))
+        log(format(jsonpath.query(obj, argv._[0])))
       } else {
         log(format(_.get(obj, argv._[0])))
       }


### PR DESCRIPTION
Currently running

```sh
cat package.json | jp -p $.author
```

fails with the message `ERROR: index.js requires query argument`. This change fixes that so that behaviour matches the usage documentation.